### PR TITLE
Fixed Build error with Vite due to preserveValueImports

### DIFF
--- a/src/components/Typed.tsx
+++ b/src/components/Typed.tsx
@@ -1,4 +1,5 @@
-import { h, ref, PropType, defineComponent, onMounted } from "vue";
+import { h, ref, defineComponent, onMounted } from "vue";
+import type {PropType} from "vue";
 import type { TypedOptions } from "typed.js";
 import Typed from "typed.js";
 import "./Typed.css";


### PR DESCRIPTION
Imported PropType as follows
```sh
import type {PropType} from "vue";
```